### PR TITLE
[Opening] continue standardisation view2d/view3d

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -14,54 +14,10 @@ vtkImage2DDisplay::vtkImage2DDisplay()
     this->WindowLevel->SetOutputFormatToRGBA();
     this->ColorWindow       = 1e-3 * VTK_DOUBLE_MAX;
     this->ColorLevel        = 0;
-    this->ColorTransferFunction   = NULL;
-    this->OpacityTransferFunction = NULL;
+    this->ColorTransferFunction   = nullptr;
+    this->OpacityTransferFunction = nullptr;
     this->UseLookupTable    = false;
 }
-
-vtkImage2DDisplay::~vtkImage2DDisplay()
-{
-}
-
-/*void vtkImage2DDisplay::SetInput(vtkAlgorithmOutput *pi_poVtkAlgoPort)
-{
-    if (pi_poVtkAlgoPort)
-    {
-        if (pi_poVtkAlgoPort->GetProducer() && pi_poVtkAlgoPort->GetProducer()->IsA("vtkImageAlgorithm"))
-        {
-            vtkAlgorithmOutput *poVtkAlgoPortTmp = pi_poVtkAlgoPort;
-            vtkImageAlgorithm *poVtkImgAlgoTmp = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoPort->GetProducer());
-            vtkImageData *poVtkImgTmp = poVtkImgAlgoTmp->GetOutput();
-
-            InputProducer = poVtkImgAlgoTmp;
-
-            m_sVtkImageInfo.SetSpacing(poVtkImgTmp->GetSpacing());
-            m_sVtkImageInfo.SetOrigin(poVtkImgTmp->GetOrigin());
-            m_sVtkImageInfo.SetScalarRange(poVtkImgTmp->GetScalarRange());
-            m_sVtkImageInfo.SetExtent(poVtkImgTmp->GetExtent());
-            m_sVtkImageInfo.SetDimensions(poVtkImgTmp->GetDimensions());
-            m_sVtkImageInfo.scalarType = poVtkImgTmp->GetScalarType();
-            m_sVtkImageInfo.nbScalarComponent = poVtkImgTmp->GetNumberOfScalarComponents();
-            m_sVtkImageInfo.initialized = true;
-
-            if (!(poVtkImgTmp->GetScalarType() == VTK_UNSIGNED_CHAR && (poVtkImgTmp->GetNumberOfScalarComponents() == 3 || poVtkImgTmp->GetNumberOfScalarComponents() == 4)))
-            {
-                this->WindowLevel->SetInputConnection(poVtkAlgoPortTmp);
-                poVtkAlgoPortTmp = this->WindowLevel->GetOutputPort();
-            }
-            this->ImageActor->GetMapper()->SetInputConnection(poVtkAlgoPortTmp);
-        }
-        else
-        {
-            vtkErrorMacro(<< "Set input prior to adding layers");
-        }
-    }
-    else
-    {
-        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
-    }
-}*/
-
 
 void vtkImage2DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
 {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -1,10 +1,24 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
 #include "vtkImage2DDisplay.h"
+
+#include <vtkAlgorithmOutput.h>
+#include <vtkImageAlgorithm.h>
 #include <vtkImageMapper3D.h>
 #include <vtkImageProperty.h>
-#include <vtkImageAlgorithm.h>
-#include <vtkAlgorithmOutput.h>
 
-vtkStandardNewMacro(vtkImage2DDisplay);
+vtkStandardNewMacro(vtkImage2DDisplay)
 
 vtkImage2DDisplay::vtkImage2DDisplay()
 {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
@@ -1,13 +1,25 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
 #pragma once
-#include <vtkImageData.h>
+
+#include <medVtkImageInfo.h>
+
+#include <vtkColorTransferFunction.h>
 #include <vtkImageActor.h>
+#include <vtkImageData.h>
 #include <vtkImageMapToColors.h>
 #include <vtkLookupTable.h>
-#include <vtkColorTransferFunction.h>
 #include <vtkPiecewiseFunction.h>
-#include <vtkSetGet.h>
-#include "medVtkImageInfo.h"
-
 
 class vtkImage2DDisplay : public vtkObject
 {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
@@ -15,8 +15,6 @@ public:
   static vtkImage2DDisplay * New();
   vtkTypeMacro (vtkImage2DDisplay, vtkObject);
 
-  //virtual void SetInput(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
-
   virtual void SetInputData(vtkImageData *pi_poVtkImage);
 
   void SetInputProducer(vtkAlgorithmOutput *pi_poAlgorithmOutput);
@@ -47,7 +45,7 @@ public:
 
 protected:
   vtkImage2DDisplay();
-  ~vtkImage2DDisplay();
+  ~vtkImage2DDisplay() = default;
 
 private:
   vtkSmartPointer<vtkImageMapToColors>        WindowLevel;

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
@@ -1,8 +1,21 @@
-#include "vtkImage3DDisplay.h"
-#include <vtkImageData.h>
-#include <vtkImageAlgorithm.h>
+/*=========================================================================
 
-vtkStandardNewMacro(vtkImage3DDisplay);
+ medInria
+
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+#include "vtkImage3DDisplay.h"
+
+#include <vtkImageAlgorithm.h>
+#include <vtkImageData.h>
+
+vtkStandardNewMacro(vtkImage3DDisplay)
 
 vtkImage3DDisplay::vtkImage3DDisplay()
 {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.cpp
@@ -23,40 +23,6 @@ vtkImage3DDisplay::~vtkImage3DDisplay()
     }
 }
 
-/*
-void vtkImage3DDisplay::SetInputConnection(vtkAlgorithmOutput* pi_poVtkAlgoPort)
-{
-    if (pi_poVtkAlgoPort)
-    {
-        if (pi_poVtkAlgoPort->GetProducer() && pi_poVtkAlgoPort->GetProducer()->IsA("vtkImageAlgorithm"))
-        {
-            this->InputConnection = pi_poVtkAlgoPort;
-            vtkImageAlgorithm* poVtkImgAlgoTmp = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoPort->GetProducer());
-            vtkImageData* poVtkImgTmp = poVtkImgAlgoTmp->GetOutput();
-
-            m_sVtkImageInfo.SetSpacing(poVtkImgTmp->GetSpacing());
-            m_sVtkImageInfo.SetOrigin(poVtkImgTmp->GetOrigin());
-            m_sVtkImageInfo.SetScalarRange(poVtkImgTmp->GetScalarRange());
-            m_sVtkImageInfo.SetExtent(poVtkImgTmp->GetExtent());
-            m_sVtkImageInfo.SetDimensions(poVtkImgTmp->GetDimensions());
-            m_sVtkImageInfo.scalarType = poVtkImgTmp->GetScalarType();
-            m_sVtkImageInfo.nbScalarComponent = poVtkImgTmp->GetNumberOfScalarComponents();
-            m_sVtkImageInfo.initialized = true;
-        }
-        else
-        {
-            vtkErrorMacro(<< "Set input prior to adding layers");
-        }
-    }
-    else
-    {
-        memset(&m_sVtkImageInfo, 0, sizeof(m_sVtkImageInfo));
-        this->InputConnection = nullptr;
-    }
-}
-*/
-
-
 void vtkImage3DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
 {
     if (pi_poVtkImage)
@@ -81,7 +47,7 @@ void vtkImage3DDisplay::SetInputProducer(vtkAlgorithmOutput *pi_poAlgorithmOutpu
     InputProducer = static_cast<vtkImageAlgorithm*>(pi_poAlgorithmOutput->GetProducer());
 }
 
-medVtkImageInfo* vtkImage3DDisplay::GetVtkImageInfo()
+medVtkImageInfo* vtkImage3DDisplay::GetMedVtkImageInfo()
 {
     return &m_sVtkImageInfo;
 }
@@ -95,8 +61,3 @@ vtkLookupTable* vtkImage3DDisplay::GetLookupTable()
 {
     return this->LookupTable;
 }
-
-/*vtkAlgorithmOutput* vtkImage3DDisplay::GetOutputPort()
-{
-    return this->InputConnection;
-}*/

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.h
@@ -15,12 +15,9 @@ public:
 
     vtkTypeMacro (vtkImage3DDisplay, vtkObject);
 
-    //vtkSetObjectMacro(InputConnection, vtkAlgorithmOutput);
-
-    //virtual void SetInputConnection(vtkAlgorithmOutput*  pi_poVtkAlgoPort);
     virtual void SetInputData(vtkImageData *pi_poVtkImage);
     void SetInputProducer(vtkAlgorithmOutput *pi_poAlgorithmOutput);
-    virtual medVtkImageInfo* GetVtkImageInfo();
+    virtual medVtkImageInfo* GetMedVtkImageInfo();
 
     virtual bool isInputSet();
 
@@ -42,7 +39,6 @@ public:
     vtkSetMacro(ColorLevel, double);
     vtkGetMacro(ColorLevel, double);
 
-    //vtkAlgorithmOutput* GetOutputPort();
     virtual vtkImageAlgorithm* GetInputProducer() const { return this->InputProducer; }
 
 protected:
@@ -50,9 +46,7 @@ protected:
     ~vtkImage3DDisplay();
 
 private:
-    //vtkSmartPointer<vtkImageData>               InputImageOld;
-    //vtkSmartPointer<vtkAlgorithmOutput>         InputConnection;
-    vtkSmartPointer<vtkImageAlgorithm>            InputProducer;
+    vtkSmartPointer<vtkImageAlgorithm> InputProducer;
     double Opacity;
     int Visibility;
     double ColorWindow;

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage3DDisplay.h
@@ -1,12 +1,24 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
+ See LICENSE.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
 #pragma once
-#include "medVtkImageInfo.h"
+
+#include <medVtkImageInfo.h>
 
 #include <vtkAlgorithmOutput.h>
 #include <vtkImageAlgorithm.h>
 #include <vtkImageData.h>
 #include <vtkLookupTable.h>
 #include <vtkSetGet.h>
-
 
 class vtkImage3DDisplay : public vtkObject
 {

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView.cxx
@@ -377,9 +377,9 @@ vtkAlgorithmOutput* vtkImageView::ResliceImageToInput(vtkAlgorithmOutput* pi_poV
 /**  Set the input image to the viewer. */
 void vtkImageView::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix /*= 0*/, int layer /*= 0*/)
 {
-    //vtkSetObjectBodyMacro (Input, vtkImageData, arg);
     m_poInputVtkAlgoOutput = pi_poVtkAlgoOutput;
-    m_poInternalImageFromInput = ((vtkImageAlgorithm*)pi_poVtkAlgoOutput->GetProducer())->GetOutput();
+    m_poInternalImageFromInput = static_cast<vtkImageAlgorithm*>(pi_poVtkAlgoOutput->GetProducer())->GetOutput();
+
     if (pi_poVtkAlgoOutput)
     {
        this->WindowLevel->SetInputConnection(pi_poVtkAlgoOutput);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
  See LICENSE.txt for details.
 
   This software is distributed WITHOUT ANY WARRANTY; without even
@@ -11,83 +11,40 @@
 
 =========================================================================*/
 
+#include "vtkImage2DDisplay.h"
 #include "vtkImageView2D.h"
 
-#include "vtkBoundingBox.h"
-#include "vtkCamera.h"
-#include "vtkCommand.h"
-#include "vtkImageActor.h"
-#include "vtkImageData.h"
-#include "vtkImageMapToColors.h"
-#include "vtkObjectFactory.h"
-#include "vtkRenderWindow.h"
-#include "vtkRenderWindowInteractor.h"
-#include "vtkRenderer.h"
-#include "vtkMatrix4x4.h"
-#include "vtkTransform.h"
-#include "vtkScalarBarActor.h"
-#include "vtkCornerAnnotation.h"
-#include "vtkTextProperty.h"
-#include "vtkLookupTable.h"
-#include "vtkMath.h"
-#include "vtkPlane.h"
-#include "vtkCutter.h"
-#include "vtkActor.h"
-#include "vtkPolyDataMapper.h"
-#include "vtkProp3DCollection.h"
-#include "vtkDataSetCollection.h"
-#include "vtkPoints.h"
-#include "vtkIdList.h"
-#include "vtkOutlineSource.h"
-#include "vtkMatrixToLinearTransform.h"
-#include "vtkPointData.h"
-#include "vtkUnsignedCharArray.h"
-#include "vtkIntArray.h"
-#include "vtkImageAccumulate.h"
-#include "vtkCoordinate.h"
-#include "vtkTextActor.h"
-#include "vtkAxisActor2D.h"
-#include "vtkProperty.h"
-#include <vtkOrientationAnnotation.h>
-#include <vtkImageView2DCommand.h>
-#include <vtkProperty2D.h>
-#include <vtkSmartPointer.h>
-#include <vtkAxisActor2D.h>
-#include <vtkAxes2DWidget.h>
-#include <vtkRulerWidget.h>
-#include "vtkDistanceWidget.h"
-#include "vtkDistanceRepresentation2D.h"
-#include "vtkAngleWidget.h"
-#include "vtkAngleRepresentation2D.h"
-#include "vtkLeaderActor2D.h"
-#include "vtkProperty2D.h"
-#include <vtkPointHandleRepresentation2D.h>
-#include <vtkDataSet2DWidget.h>
-#include <vtkImageViewCornerAnnotation.h>
-#include <vtkImageCast.h>
-#include <vtkColorTransferFunction.h>
-#include <vtkPiecewiseFunction.h>
-#include <vtkImageReslice.h>
-#include <vtkInformation.h>
-#include <vtkStreamingDemandDrivenPipeline.h>
-
-#include <vtkTextActor3D.h>
-#include <vtkImageMapper3D.h>
-
-#include <vector>
-#include <string>
-#include <sstream>
-#include <cmath>
-
-#include <vtkImageFromBoundsSource.h>
-#include <vtkRendererCollection.h>
-#include "vtkImage2DDisplay.h"
-
-#include <vtkImageAlgorithm.h>
 #include <vtkAlgorithmOutput.h>
+#include <vtkAngleWidget.h>
+#include <vtkAngleRepresentation2D.h>
+#include <vtkAxes2DWidget.h>
+#include <vtkAxisActor2D.h>
+#include <vtkCamera.h>
+#include <vtkDataSet2DWidget.h>
+#include <vtkDataSetCollection.h>
+#include <vtkDistanceWidget.h>
+#include <vtkDistanceRepresentation2D.h>
+#include <vtkImageView2DCommand.h>
+#include <vtkImageViewCornerAnnotation.h>
+#include <vtkInformation.h>
+#include <vtkLeaderActor2D.h>
+#include <vtkMatrixToLinearTransform.h>
+#include <vtkOrientationAnnotation.h>
+#include <vtkPlane.h>
+#include <vtkPointData.h>
+#include <vtkPointSet.h>
+#include <vtkPolyData.h>
+#include <vtkProp3DCollection.h>
+#include <vtkProperty2D.h>
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRulerWidget.h>
+#include <vtkScalarBarActor.h>
+#include <vtkStreamingDemandDrivenPipeline.h>
+#include <vtkTransform.h>
 
-
-vtkStandardNewMacro(vtkImageView2D);
+vtkStandardNewMacro(vtkImageView2D)
 
 //----------------------------------------------------------------------------
 vtkImageView2D::vtkImageView2D()
@@ -1729,22 +1686,9 @@ void vtkImageView2D::ApplyColorTransferFunction(vtkScalarsToColors * colors, int
 
 void vtkImageView2D::SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix, int layer)
 {
-    // TODO: not used, even if we remove/add data
-    if( layer > 0 )
-    {
-        this->AddLayer(layer);
-    }
-
     this->GetImage2DDisplayForLayer(layer)->SetInputProducer(pi_poInputAlgoImg);
     this->Superclass::SetInput (pi_poInputAlgoImg, matrix, 0);
-
     this->GetImage2DDisplayForLayer(layer)->SetInputData(m_poInternalImageFromInput);
-
-    // TODO: Not useful, and take time
-    //this->GetWindowLevel(layer)->SetInputConnection(pi_poInputAlgoImg);
-    //double *range = this->GetImage2DDisplayForLayer(layer)->GetMedVtkImageInfo()->scalarRange;
-    //this->SetColorRange(range, layer);
-    //this->Reset();
 }
 
 /**
@@ -1792,12 +1736,6 @@ void vtkImageView2D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
         {
             this->AddLayer(layer);
 
-            if (!this->GetMedVtkImageInfo() || !this->GetMedVtkImageInfo()->initialized)
-            {
-                vtkErrorMacro (<< "Set input prior to adding layers");
-                return;
-            }
-
             vtkAlgorithmOutput *reslicerOutputPort = this->ResliceImageToInput(pi_poVtkAlgoOutput, matrix);
             if (!reslicerOutputPort)
             {
@@ -1806,6 +1744,7 @@ void vtkImageView2D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
             }
 
             vtkImage2DDisplay * imageDisplay = this->GetImage2DDisplayForLayer(layer);
+            imageDisplay->SetInputProducer(reslicerOutputPort);
             imageDisplay->SetInputData(static_cast<vtkImageAlgorithm*>(reslicerOutputPort->GetProducer())->GetOutput());
             imageDisplay->GetImageActor()->SetUserMatrix (this->OrientationMatrix);
             this->SetColorRange(imageDisplay->GetMedVtkImageInfo()->scalarRange, layer);
@@ -1816,10 +1755,7 @@ void vtkImageView2D::SetInput(vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4
         vtkRenderer *renderer = this->GetRendererForLayer(layer);
         if (renderer)
         {
-            if ( this->GetImage2DDisplayForLayer(layer) )
-            {
-                renderer->AddViewProp (this->GetImage2DDisplayForLayer(layer)->GetImageActor());
-            }
+            renderer->AddViewProp (this->GetImage2DDisplayForLayer(layer)->GetImageActor());
 
             this->SetCurrentLayer(layer);
             this->Slice = this->GetSliceForWorldCoordinates (this->CurrentPoint);
@@ -1873,7 +1809,6 @@ void vtkImageView2D::SetInput (vtkActor *actor, int layer, vtkMatrix4x4 *matrix,
     this->SetCurrentLayer(layer);
     this->Slice = this->GetSliceForWorldCoordinates (this->CurrentPoint);
     this->UpdateDisplayExtent();
-    // this->UpdateCenter();
     this->UpdateSlicePlane();
     this->InvokeEvent (vtkImageView2D::SliceChangedEvent);
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.h
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
  See LICENSE.txt for details.
  
   This software is distributed WITHOUT ANY WARRANTY; without even
@@ -18,7 +18,6 @@
 
 #include <vtkImageView.h>
 #include <vtkInteractorStyleImageView2D.h>
-
 #include <vtkSmartPointer.h>
 
 #include <vector>
@@ -58,7 +57,7 @@ class vtkImageAlgorithm;
 
 
  A) SLICE_ORIENTATION enum
- the slice orientation enum has changed to match VTK : XY / XZ / YZ
+ the slice orientation enum has changed to match VTK: XY / XZ / YZ
  The axis enum is therefore of no need.
 
  B) The ImageToColor instance has been moved to ImageView (see vtkImageView.h)
@@ -66,7 +65,7 @@ class vtkImageAlgorithm;
  C) Orientation and Convention systems have been put in place,
  thus replacing the DirectionMatrix system
 
- D) The Zoom / Pan differentiation : is it needed ?
+ D) The Zoom / Pan differentiation: is it needed ?
 
  E) again here Visibility --> Show
 
@@ -76,7 +75,7 @@ class vtkImageAlgorithm;
  of the overall code. So I put it back.
  One thing remains though. Pierre differentiated the Zoom event from the Pan event,
  thus authorizing sync. of one and not the other. In the system I propose there is
- no differentiation, they are gathered in the CameraMove event. to be discussed.
+ no differentiation, they are gathered in the CameraMove event. To be discussed.
 
  G) All mouse interactions have thus been put in place.
 
@@ -133,16 +132,12 @@ public:
     virtual void SetInput (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
     virtual void SetInput (vtkActor *actor, int layer = 0, vtkMatrix4x4 *matrix = 0, const int imageSize[3] = 0, const double imageSpacing[] = 0, const double imageOrigin[] = 0);
 
-
     void RemoveLayerActor(vtkActor *actor, int layer = 0);
-    
-    //int AddInput (vtkImageData *image, vtkMatrix4x4 *matrix);
 
-    virtual vtkActor* AddDataSet (vtkPointSet* arg, vtkProperty* prop = NULL);
+    virtual vtkActor* AddDataSet (vtkPointSet* arg, vtkProperty* prop = nullptr);
     virtual void RemoveDataSet (vtkPointSet *arg);
 
     medVtkImageInfo* GetMedVtkImageInfo(int layer = 0) const;
-
 
     virtual void InstallInteractor();
     virtual void UnInstallInteractor();
@@ -151,7 +146,7 @@ public:
 
     /**
    Description:
-   The orientation of the view is a abstract representation of the object
+   The orientation of the view is an abstract representation of the object
    we are looking at. It results from the acquisition plane. Setting the View
    Orientation by calling SetViewOrientation() will imply the view to set its
    inner "slice" orientation. (slice orientation == 2 means plane of acquisition.)
@@ -441,8 +436,6 @@ protected:
     // Get layer specific renderer.
     vtkImage2DDisplay * GetImage2DDisplayForLayer(int layer) const;
     vtkRenderer * GetRendererForLayer(int layer) const;
-
-
 
     //BTX
     std::list<vtkDataSet2DWidget*>::iterator FindDataSetWidget(vtkPointSet* arg);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -148,7 +148,8 @@ public:
     virtual unsigned int GetCroppingMode ();
 
     virtual void SetInput (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = 0, int layer = 0);
-    //virtual void AddInput (vtkImageData* input, vtkMatrix4x4 *matrix = 0);
+    void SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix, int layer);
+
     virtual void SetOrientationMatrix (vtkMatrix4x4* matrix);
 
     using vtkImageView::SetColorWindow;
@@ -169,7 +170,6 @@ public:
 
     virtual void SetVisibility(int visibility, int layer);
     virtual int  GetVisibility(int layer) const;
-
 
     virtual void SetShowActorX (unsigned int);
     vtkGetMacro (ShowActorX, unsigned int);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -2,7 +2,7 @@
 
  medInria
 
- Copyright (c) INRIA 2013 - 2018. All rights reserved.
+ Copyright (c) INRIA 2013 - 2020. All rights reserved.
  See LICENSE.txt for details.
  
   This software is distributed WITHOUT ANY WARRANTY; without even
@@ -15,18 +15,12 @@
 
 #include <medVtkInriaExport.h>
 
-#include <vector>
-
 #include <vtkImageView.h>
-#include <vtkOrientedBoxWidget.h>
-
-#include <vtkPlaneWidget.h>
-#include <vtkVolume.h>
 #include <vtkImageView3DCroppingBoxCallback.h>
 #include <vtkOrientationMarkerWidget.h>
+#include <vtkOrientedBoxWidget.h>
+#include <vtkPlaneWidget.h>
 #include <vtkVolumeProperty.h>
-#include <vtkSmartPointer.h>
-
 
 class vtkVolume;
 class vtkPiecewiseFunction;
@@ -52,7 +46,7 @@ class vtkProp3DCollection;
 
    This class allows to view 3D images. Images have to be
    vtkImageData.
-   volume rendering and mulptiplane reconstructions are provided
+   volume rendering and multiplane reconstructions are provided
    remote plan can also be used, so can be an orientation cube, ...
 */
 
@@ -65,7 +59,7 @@ public:
 
     vtkMTimeType GetMTime();
 
-    // Rendeing Modes available.
+    // Rendering Modes available.
     // PLANAR_RENDERING will render every vtkImageActor instance added with Add2DPhantom()
     // whereas VOLUME_RENDERING will render the volume added with SetInputData().
     //BTX
@@ -279,9 +273,9 @@ protected:
     unsigned int ShowActorY;
     unsigned int ShowActorZ;
 
-    int          LastNodeIndex;
+    int LastNodeIndex;
 
-    int          CroppingMode;
+    int  CroppingMode;
 
     double Opacity;
     int Visibility;

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImage4DInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImage4DInteractor.cpp
@@ -117,8 +117,8 @@ void medVtkViewItkDataImage4DInteractor::setInputData(medAbstractData *data)
             d->imageData->setMetaData("SequenceDuration", QString::number(m_poConv->getTotalTime()));
             d->imageData->setMetaData("SequenceFrameRate", QString::number((double)(m_poConv->getNumberOfVolumes() -1 )/ (double)m_poConv->getTotalTime()));
 
-            dtkDebug() << "SequenceDuration" << m_poConv->getTotalTime();
-            dtkDebug() << "SequenceFrameRate" <<(double)(m_poConv->getNumberOfVolumes() -1)/ m_poConv->getTotalTime();
+            qDebug() << "SequenceDuration" << m_poConv->getTotalTime();
+            qDebug() << "SequenceFrameRate" <<(double)(m_poConv->getNumberOfVolumes() -1)/ m_poConv->getTotalTime();
 
             d->view2d->GetImageActor(d->view2d->GetCurrentLayer())->GetProperty()->SetInterpolationTypeToCubic();
             initParameters(d->imageData);

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -193,7 +193,6 @@ void medVtkViewItkDataImageInteractor::removeData()
     d->view3d->RemoveLayer(d->view->layer(d->imageData));
 }
 
-
 bool medVtkViewItkDataImageInteractor::SetViewInput(medAbstractData* data, int layer)
 {
     bool bRes = true;


### PR DESCRIPTION
Continue à faire se rejoindre vtkImage[2/3]DDisplay, et accélerer l'ouverture de données.

vtkImageView2D::SetFirstLayer -> y'a deux bouts du code qui n'ont l'air de : soit jamais être atteint, soit : ne servir à rien.

J'ai commencé de matin à 13 secondes pour l'ouverture, j'en suis à 10. Je vais voir si je peux continuer d'améliorer.

:m: