### PR TITLE
Vtk9 crash deprecated

### DIFF
--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -68,7 +68,7 @@ void forceShow(medMainWindow& mainwindow )
 
 int main(int argc,char* argv[])
 {
-    // Setup openGL surface compatible with QVTKOpenGLWidget,
+    // Setup openGL surface compatible with QVTKOpenGLNativeWidget,
     // required by medVtkView
     QSurfaceFormat fmt;
     fmt.setRenderableType(QSurfaceFormat::OpenGL);

--- a/src/layers/legacy/medVtkInria/CMakeLists.txt
+++ b/src/layers/legacy/medVtkInria/CMakeLists.txt
@@ -100,6 +100,7 @@ target_link_libraries(${TARGET_NAME}
   VTK::vtksys
   )
 
+vtk_module_autoinit(TARGETS ${TARGET_NAME} MODULES ${VTK_LIBRARIES} )
 
 ## #############################################################################
 ## install

--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -17,7 +17,7 @@
 #include <QTest>
 #include <QWidget>
 
-#include <QVTKOpenGLWidget.h>
+#include <QVTKOpenGLNativeWidget.h>
 #include <QGLFramebufferObject>
 
 #include <QVTKInteractorAdapter.h>
@@ -67,7 +67,7 @@ public:
     vtkImageView3D *view3d;
 
     vtkGenericOpenGLRenderWindow *renWin;
-    QVTKOpenGLWidget *viewWidget;
+    QVTKOpenGLNativeWidget *viewWidget;
 
     medVtkViewObserver *observer;
 
@@ -131,9 +131,9 @@ medVtkView::medVtkView(QObject* parent): medAbstractImageView(parent),
     d->view3d->SetInteractorStyle(interactorStyle);
     interactorStyle->Delete();
 
-    d->viewWidget = new QVTKOpenGLWidget();
+    d->viewWidget = new QVTKOpenGLNativeWidget();
     d->viewWidget->setEnableHiDPI(true);
-    d->viewWidget->SetRenderWindow(d->renWin);
+    d->viewWidget->setRenderWindow(d->renWin);
 
     // Event filter used to know if the view is selected or not
     d->viewWidget->installEventFilter(this);

--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -160,7 +160,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
     // Build views
     for (int i = 0; i < 4; i++)
     {
-        views[i] = new QVTKOpenGLWidget();
+        views[i] = new QVTKOpenGLNativeWidget();
         views[i]->setEnableHiDPI(true);
         views[i]->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
         views[i]->installEventFilter(this);
@@ -183,19 +183,19 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
     viewBody->setLayout(gridLayout);
 
     // Share render windows and interactors
-    views[0]->SetRenderWindow(riw[0]->GetRenderWindow());
-    riw[0]->SetupInteractor(views[0]->GetRenderWindow()->GetInteractor());
+    views[0]->setRenderWindow(riw[0]->GetRenderWindow());
+    riw[0]->SetupInteractor(views[0]->renderWindow()->GetInteractor());
 
-    views[1]->SetRenderWindow(riw[1]->GetRenderWindow());
-    riw[1]->SetupInteractor(views[1]->GetRenderWindow()->GetInteractor());
+    views[1]->setRenderWindow(riw[1]->GetRenderWindow());
+    riw[1]->SetupInteractor(views[1]->renderWindow()->GetInteractor());
 
-    views[2]->SetRenderWindow(riw[2]->GetRenderWindow());
-    riw[2]->SetupInteractor(views[2]->GetRenderWindow()->GetInteractor());
+    views[2]->setRenderWindow(riw[2]->GetRenderWindow());
+    riw[2]->SetupInteractor(views[2]->renderWindow()->GetInteractor());
 
     vtkSmartPointer<vtkRenderer> ren = vtkSmartPointer<vtkRenderer>::New();
     vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
-    views[3]->SetRenderWindow(renderWindow);
-    views[3]->GetRenderWindow()->AddRenderer(ren);
+    views[3]->setRenderWindow(renderWindow);
+    views[3]->renderWindow()->AddRenderer(ren);
 
     // Make them all share the same reslice cursor object.
     for (int i = 0; i < 3; i++)
@@ -216,7 +216,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
 
     vtkSmartPointer<vtkProperty> ipwProp = vtkSmartPointer<vtkProperty>::New();
 
-    vtkRenderWindowInteractor *iren = views[3]->GetInteractor();
+    vtkRenderWindowInteractor *iren = views[3]->interactor();
 
     // Build planes on views
     for (int i = 0; i < 3; i++)
@@ -365,7 +365,7 @@ void medResliceViewer::render()
     for (int i = 0; i < 3; i++)
     {
         riw[i]->Render();
-        views[i]->GetRenderWindow()->Render();
+        views[i]->renderWindow()->Render();
     }
 }
 
@@ -487,7 +487,7 @@ void medResliceViewer::extentChanged(int val)
 
 bool medResliceViewer::eventFilter(QObject *object, QEvent *event)
 {
-    if (!qobject_cast<QVTKOpenGLWidget*>(object))
+    if (!qobject_cast<QVTKOpenGLNativeWidget*>(object))
     {
         return true;
     }

--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -18,7 +18,7 @@ PURPOSE.
 
 #include <medAbstractView.h>
 
-#include <QVTKOpenGLWidget.h>
+#include <QVTKOpenGLNativeWidget.h>
 
 #include <resliceToolBox.h>
 
@@ -83,7 +83,7 @@ protected:
     vtkSmartPointer<vtkImagePlaneWidget> planeWidget[3];
     double planeNormal[3][3];
     QWidget *viewBody;
-    QVTKOpenGLWidget *views[4];
+    QVTKOpenGLNativeWidget *views[4];
     dtkSmartPointer<medAbstractData> inputData;
     double *outputSpacing;
     unsigned char selectedView;


### PR DESCRIPTION
 * `vtk_module_autoinit(TARGETS ${TARGET_NAME} MODULES ${VTK_LIBRARIES} )` solves the crash opening a data in a view, or importing a data. 
 *  `QVTKOpenGLWidget` is deprecated, we need to use `QVTKOpenGLNativeWidget`. By the way, there is a graphic problem in Reslice toolbox to solve (with or without the changes).